### PR TITLE
Copy typescript definitions of web output + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,20 @@ To use Smartype on Android, start by adding the generated `smartype.aar` to your
 
 ```kotlin
 dependencies {
-    implementation "com.mparticle:smartype-mparticle:1.1.0"
+    implementation "com.mparticle:smartype-api:1.2.1"
+    implementation "com.mparticle:smartype-mparticle:1.2.1"
     implementation fileTree(dir: 'libs', include: ['**/*.aar'])
+}
+```
+
+The Smartype API dependencies are deployed as a multiplatform library leveraging [Gradle Module metadata](https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html), and in order
+for Android projects to resolve the right dependency, you may need to add the following to ensure debug builds use the "release" artifact.
+
+```kotlin
+buildTypes {
+    debug {
+        matchingFallbacks = ["release"]
+    }
 }
 ```
 
@@ -153,13 +165,7 @@ Smartype `generate` will create a set of `.js` and `.d.ts` files that you can in
 To use Smartype on Web, start by adding the generated `smartype-dist` directory to your project and any 3rd-party receivers that you plan on using, then include the relevant files in your typescript or javascript sources:
 
 ```js
-import * as kotlin from "../smartype-dist/kotlin.js"
-import * as smartype from "../smartype-dist/smartype-smartype.js"
-import * as smartypeMparticle from "../smartype-dist/smartype-smartype-mparticle.js"
-
-// create namespace references for easier access
-var api = smartype.com.mparticle.smartype
-var receivers = smartypeMparticle.com.mparticle.smartype.api.receivers
+import * as smartype from "../smartype-dist/smartype.js"
 ```
 
 - Import and initialize Smartype prior to use, and register your receivers
@@ -167,14 +173,15 @@ var receivers = smartypeMparticle.com.mparticle.smartype.api.receivers
 - Pass the fully constructed objects into your `SmartypeApi` instance for all receivers 
 
 ```js
-var smartypeApi = new api.SmartypeApi()
-smartypeApi.addReceiver(new receivers.mparticle.MParticleReceiver())
-smartypeApi.addReceiver(this)
+import * as smartype from "../smartype-dist/smartype.js"
 
-var message = smartypeApi.chooseItem(
-      new api.ChooseItemData(
-        new api.ChooseItemDataCustomAttributes(
-          1, true, new api.ChooseItemDataCustomAttributesItem().CORTADO()
+var api = new smartype.SmartypeApi()
+api.addReceiver(smartype.mParticleReceiver())
+
+var message = smartype.chooseItem(
+      new smartype.ChooseItemData(
+        new smartype.ChooseItemDataCustomAttributes(
+          1, true, new smartype.ChooseItemDataCustomAttributesItem().CORTADO()
         )
       )
     )

--- a/examples/androidExample/app/build.gradle
+++ b/examples/androidExample/app/build.gradle
@@ -43,9 +43,8 @@ allprojects {
 }
 
 dependencies {
-    implementation "com.mparticle:smartype-api:1.2.0"
-    implementation "com.mparticle:smartype-mparticle:1.2.0"
-    implementation "com.mparticle:android-core:5.15.0"
+    implementation "com.mparticle:smartype-api:1.2.1"
+    implementation "com.mparticle:smartype-mparticle:1.2.1"
     implementation fileTree(dir: 'libs', include: ['**/*.aar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.0.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ kotlin.js.compiler=ir
 IS_PUBLISHED=false
 
 GROUP=com.mparticle
-VERSION_NAME=1.2.0
+VERSION_NAME=1.2.1
 

--- a/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
+++ b/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
@@ -203,6 +203,7 @@ class Generate : CliktCommand(name="generate", help = "Generate Smartype Client 
 
             if (options.webOptions.enabled) {
                 val webBuildDirectory = File(projectDirectory).resolve("smartype/build/distributions")
+                val smartypeBuildDir = File(projectDirectory).resolve("build")
                 if (webBuildDirectory.exists()) {
                     {
                         val mvWeb =
@@ -217,7 +218,19 @@ class Generate : CliktCommand(name="generate", help = "Generate Smartype Client 
                         val p5 = pb5.start()
                         p5.waitFor()
                     }();
-
+                    {
+                        val mvWeb =
+                            listOf(
+                                "cp",
+                                smartypeBuildDir.absolutePath + "/js/packages/smartype-smartype/kotlin/smartype-smartype.d.ts",
+                                File(binOutputDirectory).resolve("web").absolutePath + "/smartype.d.ts"
+                            )
+                        val pb5 = ProcessBuilder(mvWeb)
+                        pb5.redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                        pb5.redirectError(ProcessBuilder.Redirect.INHERIT)
+                        val p5 = pb5.start()
+                        p5.waitFor()
+                    }();
                 } else {
                     println("Unable to locate built Web JS distributions in ${webBuildDirectory.absolutePath}")
                 }


### PR DESCRIPTION
# Summary

In 1.2.0 we lost copying of typescript definitions for the web output - this PR restores it.

As an FYI - the reason why these are located in a strange directory rather than the distribution directory is that the Kotlin team feels this is very much an incubating feature. Eventually, these definitions will be generated along side the primary JS output. See the description here for more info: https://youtrack.jetbrains.com/issue/KT-16604
