### PR TITLE
Don't delete build dir when initializing

### DIFF
--- a/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
+++ b/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
@@ -158,7 +158,7 @@ class Generate : CliktCommand(name="generate", help = "Generate Smartype Client 
 
         val directory =
             File(System.getProperty("user.dir")).resolve(File(binOutputDirectory))
-        directory.deleteRecursively()
+
         if (!directory.exists()) {
             directory.mkdirs()
         }


### PR DESCRIPTION
# Summary

No need to delete the build directory - the build files themselves will get overwritten on build.
