### PR TITLE
fix: generate fails on certain enums and events

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,7 +40,7 @@ jobs:
     defaults:
       run:
         working-directory: examples/webExample
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -76,6 +76,10 @@ jobs:
         run: npm install
       - name: Build web app
         run: npm run build
+      - name: Run Tests
+        working-directory: test-json
+        run: bash run-all-tests.sh --platform=web --jar=../examples/webExample/smartype.jar
+
   build-android-example:
     needs: build-smartype
     defaults:
@@ -117,6 +121,9 @@ jobs:
           java -jar smartype.jar generate
       - name: Assemble Android App
         run: ./gradlew assembleRelease
+      - name: Run Tests
+        working-directory: test-json
+        run: bash run-all-tests.sh --platform=android --jar=../examples/androidExample/smartype.jar
 
   build-ios-example:
     needs: build-smartype
@@ -153,10 +160,13 @@ jobs:
           rm -f smartype-generator-*-*.jar
           mv smartype-generator-*.jar smartype.jar
       - name: Run smartype
-        run: |
-          java -jar smartype.jar generate --config=SmartypeExample/smartype.config.json
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          java -jar smartype.jar generate --config=SmartypeExample/smartype.config.json
+      - name: Run Tests
+        working-directory: test-json
+        run: bash run-all-tests.sh --platform=ios --jar=../examples/iosExample/smartype.jar
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/test-json/smartype.config.json
 .DS_Store
 .idea
 .idea/shelf

--- a/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/StringHelpers.kt
+++ b/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/StringHelpers.kt
@@ -1,12 +1,14 @@
 package com.mparticle.smartype.generator
 
+import java.util.*
+
 class StringHelpers {
     companion object {
-        fun sanitize(key: String, includeUnderscores: Boolean = false): String? {
-            val sanitizedName = stripChars(key)?.let { upperFirst(it) }
+        fun sanitize(key: String, includeUnderscores: Boolean = false, allUppercaseString: Boolean = false): String? {
+            val sanitizedName = stripChars(key)?.let { prefixNumber(it) }?.let { upperFirst(it) }
             var uppercaseName = ""
             val words = sanitizedName?.split("_")
-            if (words == null || words.count() == 0) {
+            if (words == null || words.isEmpty()) {
                 return sanitizedName
             }
             var isFirst = true
@@ -25,6 +27,9 @@ class StringHelpers {
                 } else {
                     uppercaseName = "${uppercaseName}${upperWord}"
                 }
+            }
+            if (allUppercaseString) {
+                uppercaseName = uppercaseName.toUpperCase(Locale.ROOT)
             }
             return uppercaseName
         }
@@ -82,6 +87,29 @@ class StringHelpers {
                 return null
             }
             return key.replace(Regex("\\\\"), "\\\\\\\\")
+        }
+
+        // Many identifiers cannot start with a number, so prefix strings that start with numbers
+        private fun prefixNumber(key: String?): String? {
+            if (key == null || key.isEmpty()) {
+                return null
+            }
+            if (!key[0].isDigit()) {
+                return key
+            }
+            return "prefixed_${key}"
+        }
+
+        fun dedupName(existingNames: List<String>, name: String): String {
+            var postfix = 2
+            while (true) {
+                var dedupedName = "${name}${postfix}"
+                if (existingNames.contains(dedupedName)) {
+                    postfix += 1
+                } else {
+                    return dedupedName
+                }
+            }
         }
     }
 }

--- a/test-json/options/test-duplicate-class-name.json
+++ b/test-json/options/test-duplicate-class-name.json
@@ -1,0 +1,103 @@
+{
+    "version": 1,
+    "data_plan_id": "test_plan",
+    "version_description": null,
+    "activated_environment": "none",
+    "created_on": "2021-09-27T17:41:06.087",
+    "created_by": "bbaron@mparticle.com",
+    "last_modified_on": "2021-09-27T18:10:35.633",
+    "last_modified_by": "bbaron@mparticle.com",
+    "version_document": {
+      "data_points": [
+        {
+          "description": "",
+          "match": {
+            "type": "custom_event",
+            "criteria": {
+              "event_name": "Coupon Used",
+              "custom_event_type": "transaction"
+            }
+          },
+          "validator": {
+            "type": "json_schema",
+            "definition": {
+              "properties": {
+                "data": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "custom_attributes": {
+                      "additionalProperties": false,
+                      "description": "",
+                      "properties": {
+                        "Coupon Type": {
+                          "description": "describes what kind of coupon",
+                          "enum": [
+                            "Discount",
+                            "Promotion",
+                            "Holiday Discount"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "Coupon Type"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "custom_attributes"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "",
+          "match": {
+            "type": "custom_event",
+            "criteria": {
+              "event_name": "Coupon Used",
+              "custom_event_type": "other"
+            }
+          },
+          "validator": {
+            "type": "json_schema",
+            "definition": {
+              "properties": {
+                "data": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "custom_attributes": {
+                      "additionalProperties": false,
+                      "description": "",
+                      "properties": {
+                        "test": {
+                          "description": "",
+                          "enum": [
+                            "testval1",
+                            "testval2"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "test"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "custom_attributes"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/test-json/options/test-enum-value-starting-with-number.json
+++ b/test-json/options/test-enum-value-starting-with-number.json
@@ -1,0 +1,60 @@
+{
+    "version": 1,
+    "data_plan_id": "test_plan",
+    "version_description": null,
+    "activated_environment": "none",
+    "created_on": "2021-09-27T17:41:06.087",
+    "created_by": "bbaron@mparticle.com",
+    "last_modified_on": "2021-09-27T18:10:35.633",
+    "last_modified_by": "bbaron@mparticle.com",
+    "version_document": {
+      "data_points": [
+        {
+          "description": "",
+          "match": {
+            "type": "custom_event",
+            "criteria": {
+              "event_name": "Coupon Used",
+              "custom_event_type": "other"
+            }
+          },
+          "validator": {
+            "type": "json_schema",
+            "definition": {
+              "properties": {
+                "data": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "custom_attributes": {
+                      "additionalProperties": false,
+                      "description": "",
+                      "properties": {
+                        "test": {
+                          "description": "",
+                          "enum": [
+                            "1test",
+                            "2",
+                            "50points",
+                            "two"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "test"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "custom_attributes"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/test-json/run-all-tests.sh
+++ b/test-json/run-all-tests.sh
@@ -1,0 +1,121 @@
+#
+# Constants
+#
+
+# Script Constants
+readonly VALID_PLATFORMS="android ios web"
+readonly OPTIONS_PATH="./options"
+
+# Terminal Formatting
+export FONT_RESET=$(tput sgr0)
+export FONT_BOLD=$(tput bold)
+
+#
+# Helper Functions
+#
+
+contains() {
+    [[ "$1" =~ (^|[[:space:]])"$2"($|[[:space:]]) ]]
+}
+
+#
+# Arguments
+#
+
+print_usage() {
+    printf "${FONT_BOLD}Usage:${FONT_RESET} $0 --platform={android|ios|web} --jar=path/to/jar \n"
+}
+
+validate_args() {
+    if ! contains "$VALID_PLATFORMS" "$platform"; then
+        printf "${FONT_BOLD}Error:${FONT_RESET} Invalid platform\n"
+        print_usage
+        exit 1
+    fi
+
+    if [[ ! -f "$jar" ]]; then
+        printf "${FONT_BOLD}Error:${FONT_RESET} Invalid jar path\n"
+        print_usage
+        exit 1
+    fi
+}
+
+validate_paths() {
+    if [[ ! -d "$OPTIONS_PATH" ]]; then
+        printf "${FONT_BOLD}Error:${FONT_RESET} The ./options path does not exist, make sure to run this from within the test-json directory\n"
+        print_usage
+        exit 1
+    fi
+}
+
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --platform=*)
+                platform="${1#*=}"
+                ;;
+            --jar=*)
+                jar="${1#*=}"
+                ;;
+            *)
+                print_usage
+                exit 1
+        esac
+        shift
+    done
+
+    validate_args
+    validate_paths
+}
+
+#
+# Run Tests
+#
+
+reset() {
+    rm -rf ./smartype smartype-dist
+}
+
+print_tests() {
+    printf "${FONT_BOLD}Running Code Generation Tests${FONT_RESET}\n\n"
+    printf "${FONT_BOLD}Platform:${FONT_RESET} $platform\n"    
+
+    printf "${FONT_BOLD}Testing Options Files:${FONT_RESET}\n"
+    for i in $OPTIONS_PATH/*.json; do
+        printf "  ${i##*/}\n"
+    done
+    printf "\n\n"
+}
+
+run_tests() {
+    for i in $OPTIONS_PATH/*.json; do
+        printf "${FONT_BOLD}%s\n" "--------------------------------------------------------------------------------"
+        printf "Testing: ${i##*/}\n"
+        printf "%s${FONT_RESET}\n\n" "--------------------------------------------------------------------------------"
+
+        # Generate config
+        echo "{\"${platform}Options\": {\"enabled\": true}, \"binaryOutputDirectory\": \"smartype-dist\", \"apiSchemaFile\": \"$i\"}" > ./smartype.config.json
+
+        # Run test
+        reset
+        java -jar $jar generate --config ./smartype.config.json
+        
+        # Check result
+        if [[ $? -eq 1 ]]; then
+            printf "\n${FONT_BOLD}Test FAILED!${FONT_RESET}\n"
+            reset
+            exit 1
+        fi
+
+        printf "\n"
+    done
+    reset
+}
+
+#
+# Main
+#
+
+parse_args "$@"
+print_tests
+run_tests


### PR DESCRIPTION
# Summary

In cases where enum values start with a number, generate would fail because enum values in Kotlin can’t start with numbers (nor in the generated languages). This was also affecting other names that start with numbers where in code they can’t. So in those cases, the name is now prefixed with the word “prefixed_” to allow it to succeed.

There was also a case where 2 events with the same name but different event types would generated identially named classes, which failed due to that conflict. In this case, a number is postpended to the name (e.g. EventName, EventName2, EventName3, etc) to prevent the name collisions.

Additionally, I added a basic integration testing framework that uses a bash script and a folder of smartype options json file to run the generate step on known broken json files (can be run locally and is now also run in CI). This allows us to add new broken json options files for bugs we fix and see them pass after the fix., and also prevent regressions in the future. Later this may be expanded to compare against previously generated code as well as test the generated code to see if it compiles, but for now it just tests that code generates successfully.
