### PR TITLE
fix: fix multiplatform versioning

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,13 +1,13 @@
 object versions {
-    const val kotlin = "1.4.31"
+    const val kotlin = "1.6.10"
     const val dokka = "1.5.0"
     const val spotless = "3.27.0"
-    const val serialization = "1.1.0"
+    const val serialization = "1.6.10"
 }
 
 object deps {
     object android {
-        const val gradlePlugin = "com.android.tools.build:gradle:4.0.2"
+        const val gradlePlugin = "com.android.tools.build:gradle:7.1.0"
     }
     object mparticle {
         const val androidSdk = "com.mparticle:android-core:5.16.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Summary

Smartype Library was incompatible with mParticle iOS SDK v8.6.0 because of Xcode 13 changes required an update for multiplatform dependencies.
