### PR TITLE
feat: update to latest dependencies

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -175,11 +175,52 @@ jobs:
       - name: Run Tests
         working-directory: test-json
         run: bash run-all-tests.sh --platform=ios --jar=../examples/iosExample/smartype.jar
+  generate-all:
+    name: "Generate, All Platforms "
+    needs: build-smartype
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.15
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.15
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Install Cocoapods
+        run: sudo gem install cocoapods; sudo gem install cocoapods-generate
+      - name: pre-create maven dir
+        run: |
+          mkdir -p ~/.m2/repository/com/mparticle
+      - name: Download maven repo
+        uses: actions/download-artifact@v2
+        with:
+          name: generator-maven
+          path: ~/.m2/repository/com/mparticle
+      - name: Download generator
+        uses: actions/download-artifact@v2
+        with:
+          name: generator-jar
+      - name: rename generator jar
+        run: |
+          rm -f smartype-generator-*-*.jar
+          mv smartype-generator-*.jar smartype.jar
+      - name: Run smartype
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          java -jar smartype.jar generate
+
   publish:
     name: "Publish"
     runs-on: macOS-latest
     if: github.ref == 'refs/heads/main'
-    needs: [build-web-example, build-ios-example, build-android-example]
+    needs: [build-web-example, build-ios-example, build-android-example, generate-all]
 
     steps:
       - name: Checkout
@@ -201,7 +242,7 @@ jobs:
   automerge:
     name: "Automerge Dependabot PRs"
     runs-on: ubuntu-18.04
-    needs: [build-ios-example, build-android-example, build-web-example]
+    needs: [build-ios-example, build-android-example, build-web-example, generate-all]
     if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
     steps:
       - name: Rebase Dependabot PR

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.15
+    - name: Install Cocoapods
+      run: sudo gem install cocoapods; sudo gem install cocoapods-generate
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
@@ -142,6 +144,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.15
+      - name: Install Cocoapods
+        run: sudo gem install cocoapods; sudo gem install cocoapods-generate
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ Carthage.xcodeproj/
 **/Smartype.framework
 **/Cartfile.resolved
 **/*.xcworkspace
+kotlin-js-store/yarn.lock
+**/*.podspec

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ You can also (optionally) add yourself as a receiver, and then implement a `rece
 
 #### iOS
 
-Smartype `generate` will create a "fat" dynamic framework that you can include directly with your projects.
+Smartype `generate` will create an "fat" dynamic framework that you can include directly with your projects.
 
-- To use Smartype on iOS, start by adding `Smartype.framework` to your Xcode project
+- To use Smartype on iOS, start by adding `smartype.xcframework` to your Xcode project
 - Next, import and initialize Smartype prior to use, and register any receivers
 - The `SmartypeApi` object will surface a series of methods which each represent the top-level items in your schema
 - Pass the fully constructed objects into your `SmartypeApi` instance for all receivers 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath(deps.android.gradlePlugin)
@@ -30,7 +29,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
     tasks.withType<KotlinCompile> {
         kotlinOptions {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,11 +2,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
-    kotlin("jvm") version "1.4.31"
+    kotlin("jvm") version "1.6.10"
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_14

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,16 +1,16 @@
 object versions {
-    const val kotlin = "1.4.31"
+    const val kotlin = "1.6.10"
     const val dokka = "1.5.0"
     const val spotless = "3.27.0"
-    const val serialization = "1.1.0"
+    const val serialization = "1.3.2"
 }
 
 object deps {
     object android {
-        const val gradlePlugin = "com.android.tools.build:gradle:4.0.2"
+        const val gradlePlugin = "com.android.tools.build:gradle:7.1.0"
     }
     object mparticle {
-        const val androidSdk = "com.mparticle:android-core:5.16.1"
+        const val androidSdk = "com.mparticle:android-core:5.36.2"
         const val webSdk = "@mparticle/web-sdk"
     }
 }

--- a/examples/androidExample/app/build.gradle
+++ b/examples/androidExample/app/build.gradle
@@ -3,12 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdk 31
     defaultConfig {
         applicationId "com.mparticle.smartypeexample"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdk 21
+        targetSdk 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -30,7 +29,6 @@ android {
     buildscript {
         repositories {
             mavenLocal()
-            jcenter()
             mavenCentral()
         }
     }

--- a/examples/androidExample/build.gradle
+++ b/examples/androidExample/build.gradle
@@ -1,14 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
-        jcenter()
-        
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,7 +18,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/examples/androidExample/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/androidExample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 apply from: project.rootProject.file('gradle/maven-metadata.gradle')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/smartype-api/build.gradle.kts
+++ b/smartype-api/build.gradle.kts
@@ -25,10 +25,10 @@ kotlin {
 
     explicitApi()
 
-    js {
+    js("js") {
         browser()
     }
-    jvm()
+    jvm("jvm") {}
     android("android") {
         publishLibraryVariants("release")
     }
@@ -54,9 +54,11 @@ kotlin {
                 implementation(kotlin("test-annotations-common"))
             }
         }
-
-        val androidMain by getting {
+        val jvmMain by getting {
             dependsOn(commonMain)
+        }
+        val androidMain by getting {
+            dependsOn(jvmMain)
         }
 
         val jsMain by getting {
@@ -78,11 +80,10 @@ tasks {
 
 
 android {
-    compileSdkVersion(29)
-    buildToolsVersion("29.0.2")
+    compileSdk = 31
     defaultConfig {
-        minSdkVersion(19)
-        targetSdkVersion(29)
+        minSdk = 19
+        targetSdk = 31
     }
     sourceSets {
         getByName("main") {
@@ -91,10 +92,10 @@ android {
             res.srcDirs(file("src/androidMain/res"))
         }
     }
-    lintOptions {
+    lint {
         //TODO: remove this
         //due to a bug in mP Android SDK lint checks
-        isAbortOnError = false
+        abortOnError = false
     }
 }
 

--- a/smartype-api/src/commonMain/kotlin/com/mparticle/smartype/api/MessageReceiver.kt
+++ b/smartype-api/src/commonMain/kotlin/com/mparticle/smartype/api/MessageReceiver.kt
@@ -1,11 +1,6 @@
 package com.mparticle.smartype.api
 
-import kotlinx.serialization.json.JsonObject
-import kotlin.js.JsExport
-import kotlin.js.JsName
 
-@JsExport
-public interface MessageReceiver {
-    @JsName("receive")
+public expect interface MessageReceiver {
     public fun receive(message: String)
 }

--- a/smartype-api/src/commonMain/kotlin/com/mparticle/smartype/api/Serializable.kt
+++ b/smartype-api/src/commonMain/kotlin/com/mparticle/smartype/api/Serializable.kt
@@ -4,8 +4,6 @@ import kotlin.js.JsExport
 import kotlinx.serialization.json.JsonObject
 import kotlin.js.JsName
 
-@JsExport
-public interface Serializable {
-    @JsName("toJson")
+public expect interface Serializable {
     public fun toJson(): String
 }

--- a/smartype-api/src/iosMain/kotlin/com/mparticle/smartype/api/MessageReceiver.kt
+++ b/smartype-api/src/iosMain/kotlin/com/mparticle/smartype/api/MessageReceiver.kt
@@ -1,0 +1,5 @@
+package com.mparticle.smartype.api
+
+public actual interface MessageReceiver {
+    public actual fun receive(message: String)
+}

--- a/smartype-api/src/iosMain/kotlin/com/mparticle/smartype/api/Serializable.kt
+++ b/smartype-api/src/iosMain/kotlin/com/mparticle/smartype/api/Serializable.kt
@@ -1,0 +1,5 @@
+package com.mparticle.smartype.api
+
+public actual interface Serializable {
+    public actual fun toJson(): String
+}

--- a/smartype-api/src/jsMain/kotlin/com.mparticle.smartype.api/MessageReceiver.kt
+++ b/smartype-api/src/jsMain/kotlin/com.mparticle.smartype.api/MessageReceiver.kt
@@ -1,0 +1,7 @@
+package com.mparticle.smartype.api
+
+@JsExport
+public actual external interface MessageReceiver {
+    @JsName("receive")
+    public actual fun receive(message: String)
+}

--- a/smartype-api/src/jsMain/kotlin/com.mparticle.smartype.api/Serializable.kt
+++ b/smartype-api/src/jsMain/kotlin/com.mparticle.smartype.api/Serializable.kt
@@ -1,0 +1,7 @@
+package com.mparticle.smartype.api
+
+@JsExport
+public actual external interface Serializable {
+    @JsName("toJson")
+    public actual fun toJson(): String
+}

--- a/smartype-api/src/jvmMain/kotlin/com.mparticle.smartype.api/MessageReceiver.kt
+++ b/smartype-api/src/jvmMain/kotlin/com.mparticle.smartype.api/MessageReceiver.kt
@@ -1,0 +1,5 @@
+package com.mparticle.smartype.api
+
+public actual interface MessageReceiver {
+    public actual fun receive(message: String)
+}

--- a/smartype-api/src/jvmMain/kotlin/com.mparticle.smartype.api/Serializable.kt
+++ b/smartype-api/src/jvmMain/kotlin/com.mparticle.smartype.api/Serializable.kt
@@ -1,0 +1,5 @@
+package com.mparticle.smartype.api
+
+public actual interface Serializable {
+    public actual fun toJson(): String
+}

--- a/smartype-generator/build.gradle.kts
+++ b/smartype-generator/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.file.DuplicatesStrategy.*
+
 plugins {
     kotlin("jvm")
     id("application")
@@ -19,7 +21,7 @@ dependencies {
     implementation("com.github.ajalt:clikt:2.6.0")
     implementation("com.squareup:kotlinpoet:1.7.2")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${versions.serialization}")
-    api(project(path=":smartype-api", configuration = "jvmDefault"))
+    api(project(path=":smartype-api"))
 }
 java {
     withJavadocJar()
@@ -35,6 +37,7 @@ val fatJar = task("fatJar", type = Jar::class) {
     from({
         configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
     })
+    duplicatesStrategy = WARN
     manifest {
         attributes(mapOf("Main-Class" to application.mainClassName ))
     }
@@ -49,7 +52,6 @@ val fatJar = task("fatJar", type = Jar::class) {
         "**/*.iml",
         "**/[.].*",
         "**/[.]",
-        "**/Carthage",
         "**/smartype-receivers",
         "**/smartype-api",
         "**/local.properties")

--- a/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
+++ b/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
@@ -125,7 +125,7 @@ class Generate : CliktCommand(name="generate", help = "Generate Smartype Client 
             gradleArgs.add(":smartype:bundleReleaseAar")
         }
         if (options.iosOptions.enabled) {
-            gradleArgs.add(":smartype:iosFatFramework")
+            gradleArgs.add(":smartype:assembleReleaseXCFramework")
         }
         if (options.webOptions.enabled) {
             gradleArgs.add(":smartype:jsBrowserDistribution")
@@ -153,10 +153,10 @@ class Generate : CliktCommand(name="generate", help = "Generate Smartype Client 
         }
 
         if (options.iosOptions.enabled) {
-            val iosBuildDirectory = File(projectDirectory).resolve("smartype/build/ios")
+            val iosBuildDirectory = File(projectDirectory).resolve("smartype/build/XCFrameworks/release")
             if (iosBuildDirectory.exists()) {
                 val mviOS =
-                    listOf("mv", iosBuildDirectory.absolutePath, File(binOutputDirectory).absolutePath + "/")
+                    listOf("mv", iosBuildDirectory.absolutePath, File(binOutputDirectory).resolve("ios/").absolutePath + "/")
                 val pb3 = ProcessBuilder(mviOS)
                 pb3.redirectOutput(ProcessBuilder.Redirect.INHERIT)
                 pb3.redirectError(ProcessBuilder.Redirect.INHERIT)
@@ -190,32 +190,28 @@ class Generate : CliktCommand(name="generate", help = "Generate Smartype Client 
             val webBuildDirectory = File(projectDirectory).resolve("smartype/build/distributions")
             val smartypeBuildDir = File(projectDirectory).resolve("build")
             if (webBuildDirectory.exists()) {
-                {
-                    val mvWeb =
-                        listOf(
-                            "mv",
-                            webBuildDirectory.absolutePath,
-                            File(binOutputDirectory).resolve("web").absolutePath
-                        )
-                    val pb5 = ProcessBuilder(mvWeb)
-                    pb5.redirectOutput(ProcessBuilder.Redirect.INHERIT)
-                    pb5.redirectError(ProcessBuilder.Redirect.INHERIT)
-                    val p5 = pb5.start()
-                    p5.waitFor()
-                }();
-                {
-                    val mvWeb =
-                        listOf(
-                            "cp",
-                            smartypeBuildDir.absolutePath + "/js/packages/smartype-smartype/kotlin/smartype-smartype.d.ts",
-                            File(binOutputDirectory).resolve("web").absolutePath + "/smartype.d.ts"
-                        )
-                    val pb5 = ProcessBuilder(mvWeb)
-                    pb5.redirectOutput(ProcessBuilder.Redirect.INHERIT)
-                    pb5.redirectError(ProcessBuilder.Redirect.INHERIT)
-                    val p5 = pb5.start()
-                    p5.waitFor()
-                }();
+                val mvWeb =
+                    listOf(
+                        "mv",
+                        webBuildDirectory.absolutePath,
+                        File(binOutputDirectory).resolve("web").absolutePath
+                    )
+                val pb5 = ProcessBuilder(mvWeb)
+                pb5.redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                pb5.redirectError(ProcessBuilder.Redirect.INHERIT)
+                val p5 = pb5.start()
+                p5.waitFor();
+                val mvWeb1 =
+                    listOf(
+                        "cp",
+                        smartypeBuildDir.absolutePath + "/js/packages/smartype-smartype/kotlin/smartype-smartype.d.ts",
+                        File(binOutputDirectory).resolve("web").absolutePath + "/smartype.d.ts"
+                    )
+                val pb51 = ProcessBuilder(mvWeb1)
+                pb51.redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                pb51.redirectError(ProcessBuilder.Redirect.INHERIT)
+                val p51 = pb51.start()
+                p51.waitFor();
             } else {
                 throw CliktError("Web build failed: unable to locate built Web JS distributions in ${webBuildDirectory.absolutePath}")
             }

--- a/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
+++ b/smartype-generator/src/main/kotlin/com/mparticle/smartype/generator/Generator.kt
@@ -13,7 +13,7 @@ import com.mparticle.smartype.generator.adapters.MParticleDataPlanAdapter
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import java.io.File
-import java.util.*
+import java.util.Objects
 
 
 class Init : CliktCommand(name="init", help = "Initialize a 'smartype.config.json' configuration file") {
@@ -96,24 +96,13 @@ class Generate : CliktCommand(name="generate", help = "Generate Smartype Client 
         val adapter = DefaultAdapterFactory().createFromName(MParticleDataPlanAdapter().getName())
         val analyticsSchema = adapter.extractSchemas(jsonSchema)
 
-        if (options.iosOptions.enabled || options.androidOptions.enabled) {
+        if (options.run { androidOptions.enabled || iosOptions.enabled || webOptions.enabled }) {
             val smartTypeClass = SmartypeObject(options)
             smartTypeClass.configureApi(analyticsSchema)
 
             var outDirectory = TEMP_DIR + "smartype-generator/build/generatedSources"
             if (!inJar) {
                 outDirectory = "build/generatedSources"
-            }
-            smartTypeClass.finalize(outDirectory)
-        }
-
-        if (options.webOptions.enabled) {
-            val smartTypeClass = SmartypeObject(options)
-            smartTypeClass.configureApi(analyticsSchema)
-
-            var outDirectory = TEMP_DIR + "smartype-generator/build/generatedWebSources"
-            if (!inJar) {
-                outDirectory = "build/generatedWebSources"
             }
             smartTypeClass.finalize(outDirectory)
         }
@@ -239,3 +228,5 @@ class Generator: CliktCommand(printHelpOnEmptyArgs = true) {
 }
 
 fun main(args: Array<String>) = Generator().subcommands(Generate(), Init(), Clean()).main(args)
+
+fun <T> T.`if`(conditional: T.() -> Boolean): T? = if (conditional(this)) this else null

--- a/smartype-receivers/smartype-mparticle/src/commonMain/kotlin/com/mparticle/smartype/api/receivers/mparticle/MParticleReceiver.kt
+++ b/smartype-receivers/smartype-mparticle/src/commonMain/kotlin/com/mparticle/smartype/api/receivers/mparticle/MParticleReceiver.kt
@@ -1,9 +1,6 @@
 package com.mparticle.smartype.api.receivers.mparticle
 
-import com.mparticle.smartype.api.Message
 import com.mparticle.smartype.api.MessageReceiver
-import com.mparticle.smartype.api.receivers.mparticle.models.CustomEvent
-import kotlin.js.JsExport
 
 expect class MParticleReceiver : MessageReceiver {
 

--- a/smartype-receivers/smartype-mparticle/src/iosMain/kotlin/com/mparticle/smartype/api/receivers/mparticle/MParticleReceiver.kt
+++ b/smartype-receivers/smartype-mparticle/src/iosMain/kotlin/com/mparticle/smartype/api/receivers/mparticle/MParticleReceiver.kt
@@ -1,10 +1,7 @@
 package com.mparticle.smartype.api.receivers.mparticle
 
 import com.mparticle.smartype.api.MessageReceiver
-import com.mparticle.applesdk.*
-import platform.Foundation.NSLog
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonElement
+import cocoapods.mParticle_Apple_SDK.*
 import kotlinx.serialization.json.JsonPrimitive
 import com.mparticle.smartype.api.receivers.mparticle.models.CustomEvent
 import com.mparticle.smartype.api.receivers.mparticle.models.CustomEventType

--- a/smartype-receivers/smartype-mparticle/src/jsMain/kotlin/com/mparticle/smartype/api/receivers/mparticle/MParticleReceiver.kt
+++ b/smartype-receivers/smartype-mparticle/src/jsMain/kotlin/com/mparticle/smartype/api/receivers/mparticle/MParticleReceiver.kt
@@ -5,7 +5,6 @@ import com.mparticle.smartype.api.receivers.mparticle.models.CustomEvent
 import com.mparticle.smartype.api.receivers.mparticle.models.CustomEventType
 import com.mparticle.smartype.api.receivers.mparticle.models.ScreenViewEvent
 import kotlinx.browser.window
-import kotlinx.serialization.json.JsonPrimitive
 import org.w3c.dom.get
 
 external class mParticle {

--- a/smartype.config.json
+++ b/smartype.config.json
@@ -1,10 +1,13 @@
 {
     "iosOptions": {
-        "enabled": false
+        "enabled": true
     },
     "androidOptions": {
         "enabled": true
     },
+    "webOptions": {
+        "enabled": true
+    },
     "binaryOutputDirectory": "smartype-dist",
-    "apiSchemaFile": "../examples/iosExample/SmartypeExample/freddy_s_plan-v1.json"
+    "apiSchemaFile": "examples/iosExample/SmartypeExample/freddy_s_plan-v1.json"
 }

--- a/smartype/build.gradle.kts
+++ b/smartype/build.gradle.kts
@@ -1,6 +1,7 @@
-import org.jetbrains.kotlin.cli.jvm.main
+
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetPreset
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     kotlin("multiplatform")
@@ -24,6 +25,7 @@ group = GROUP
 version = VERSION_NAME
 
 kotlin {
+    val xcFramework = XCFramework()
 
         js {
             browser {
@@ -41,8 +43,16 @@ kotlin {
         }
     }
 
-    ios {
-        binaries.framework()
+    iosX64 {
+        binaries.framework(listOf(NativeBuildType.RELEASE)) {
+            xcFramework.add(this)
+        }
+    }
+
+    iosArm64 {
+        binaries.framework(listOf(NativeBuildType.RELEASE)) {
+            xcFramework.add(this)
+        }
     }
 
     cocoapods {
@@ -117,19 +127,24 @@ kotlin {
             if (jsMain != null) {
                 jsMain.dependsOn(commonMain)
             }
-        }catch (e: kotlin.Exception){}
+        } catch (e: kotlin.Exception) {
+        }
 
         try {
             val iosX64Main by getting {
                 dependsOn(commonMain)
+                kotlin.srcDir("src/iosMain")
             }
-        }catch (e: kotlin.Exception){}
+        } catch (e: kotlin.Exception) {
+        }
 
         try {
             val iosArm64Main by getting {
                 dependsOn(commonMain)
+                kotlin.srcDir("src/iosMain")
             }
-        }catch (e: kotlin.Exception){}
+        } catch (e: kotlin.Exception) {
+        }
     }
 }
 

--- a/smartype/build.gradle.kts
+++ b/smartype/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization") version versions.kotlin
     id("com.android.library")
+    kotlin("native.cocoapods")
 }
 
 repositories {
@@ -21,8 +22,6 @@ val IS_PUBLISHED: String by project
 
 group = GROUP
 version = VERSION_NAME
-
-val carthageBuildDir = "$projectDir/Carthage/Build/iOS"
 
 kotlin {
 
@@ -42,29 +41,18 @@ kotlin {
         }
     }
 
-    ios() {
-        compilations {
-            getByName("main") {
-                source(sourceSets.getByName("iosMain"))
-                kotlinOptions.freeCompilerArgs = listOf("-verbose")
-            }
+    ios {
+        binaries.framework()
+    }
+
+    cocoapods {
+        framework {
+            summary = "MParticle Smartype"
+            homepage = "."
+            baseName = "mParticle_Smartype"
+            ios.deploymentTarget = "14.3"
         }
-        binaries {
-            framework(listOf(RELEASE)) {
-                baseName = "Smartype"
-                transitiveExport = true
-                if (IS_PUBLISHED.toBoolean()) {
-                    export("com.mparticle:smartype-mparticle:${project.version}")
-                    export("com.mparticle:smartype-api:${project.version}")
-                } else {
-                    export(project(":smartype-api"))
-                    export(project(":smartype-receivers:smartype-mparticle"))
-                }
-                linkerOpts.add("-F${carthageBuildDir}")
-                linkerOpts.add("-framework")
-                linkerOpts.add("mParticle_Apple_SDK")
-            }
-        }
+        pod("mParticle-Apple-SDK/mParticle")
     }
 
     tasks.create("iosFatFramework", org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask::class) {
@@ -144,34 +132,12 @@ kotlin {
         }catch (e: kotlin.Exception){}
     }
 }
-listOf("bootstrap", "update").forEach { type ->
-    task<Exec>("carthage${type.capitalize()}") {
-        commandLine("$rootDir/gradle/carthage.sh")
-        args(
-            type,
-            "--platform", "iOS",
-            "--cache-builds"
-        )
-    }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink> {
-    dependsOn("carthageBootstrap")
-}
-
-
-// Delete build directory on clean
-tasks.named<Delete>("clean") {
-    delete(buildDir)
-    delete(carthageBuildDir)
-}
 
 android {
-    compileSdkVersion(30)
-    buildToolsVersion("29.0.2")
+    compileSdk = 31
     defaultConfig {
-        minSdkVersion(19)
-        targetSdkVersion(30)
+        minSdk = 19
+        targetSdk = 31
     }
     sourceSets {
         getByName("main") {


### PR DESCRIPTION
(Draft to test CI checks with passing tests)

# Summary

Primary Changes:
- update KMP, Kotlin dependency -> 1.6.10
- update AGP -> 7.1.2
- update Gradle -> 7.3.2
- update kotlinx.serialization -> 1.3.2 (latest)

Secondary Changes
- `@JSExport` is no longer allowed in common modules as of Kotlin 1.5, so I had to spread `Serializable.kt` and `MessageReceiver.kt` files from common into their individual platform directories and add the annotation in the `jsMain` package
- `configuration = jvmDefault` was removed, we used this to pull in the jvm build from a multiplatform module into a pure-java module, multiplatform plugin is now smart enough to do that on it's own
- Carthage cinterops broke with one of these changes, I replaced the manual configuration we did with the `native.cocoapods` plugin..much more modern and easy to configure. I also added the neccessary CI steps to pull in the required env dependencies
- update AGP fields in the `android { }` closure to avoid using methods deprecated in AGP 7x...`targetSdkVersion` -> `targetSdk` for example

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-3485