### PR TITLE
fix: fix ci for ios

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,6 +13,11 @@ jobs:
     name: "Build Smartype"
     runs-on: macOS-latest
     steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+      with:
+        ruby-version: '2.7'
     - uses: actions/checkout@v2
     - name: set up JDK 1.15
       uses: actions/setup-java@v1
@@ -142,6 +147,11 @@ jobs:
     runs-on: macOS-latest
 
     steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        with:
+          ruby-version: '2.7'
       - uses: actions/checkout@v2
       - name: set up JDK 1.15
         uses: actions/setup-java@v1
@@ -184,6 +194,11 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        with:
+          ruby-version: '2.7'
       - uses: actions/checkout@v2
       - name: set up JDK 1.15
         uses: actions/setup-java@v1

--- a/smartype/build.gradle.kts
+++ b/smartype/build.gradle.kts
@@ -46,12 +46,14 @@ kotlin {
     iosX64 {
         binaries.framework(listOf(NativeBuildType.RELEASE)) {
             xcFramework.add(this)
+            embedBitcode("disable")
         }
     }
 
     iosArm64 {
         binaries.framework(listOf(NativeBuildType.RELEASE)) {
             xcFramework.add(this)
+            embedBitcode("disable")
         }
     }
 


### PR DESCRIPTION
## Summary
- Set CI to use Ruby 2.7 and disable Kotlin Multiplatform from requiring bitcode frameworks

## Testing Plan
- Tested through CI

## Reference Issue
- Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4644